### PR TITLE
Support for :credentials on Rails v5.2.x.

### DIFF
--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -32,7 +32,9 @@ module Devise
     end
 
     initializer "devise.secret_key" do |app|
-      if app.respond_to?(:secrets)
+      if app.respond_to?(:credentials)
+        Devise.secret_key ||= app.credentials.secret_key_base
+      elsif app.respond_to?(:secrets)
         Devise.secret_key ||= app.secrets.secret_key_base
       elsif app.config.respond_to?(:secret_key_base)
         Devise.secret_key ||= app.config.secret_key_base


### PR DESCRIPTION
> Rails introduced :secrets in v5.1. They somehow changed it to :credentials. This fix represents this change.
> Devise will now look :credentials first, then fallback to :secrets for 5.1.x compatibility then it will check for standard secret key. If three not found then exception will arise.